### PR TITLE
Fix hobby for event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "stimulus-rails"
 gem "jbuilder"
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,10 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
+    redis (5.1.0)
+      redis-client (>= 0.17.0)
+    redis-client (0.21.1)
+      connection_pool
     regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)
@@ -330,6 +334,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  redis (>= 4.0.1)
   sassc-rails
   selenium-webdriver
   simple_form!

--- a/app/javascript/controllers/hobby_selection_controller.js
+++ b/app/javascript/controllers/hobby_selection_controller.js
@@ -11,7 +11,6 @@ export default class extends Controller {
   select() {
     let selectedCount = 0;
 
-    // Count the number of selected checkboxes
     this.checkboxTargets.forEach(checkbox => {
       if (checkbox.checked) {
         selectedCount++;
@@ -22,7 +21,7 @@ export default class extends Controller {
 
     const maxlimit = 6;
 
-    // Disable extra checkboxes if the maximum limit is reached
+
     if (selectedCount >= maxlimit) {
       this.checkboxTargets.forEach(checkbox => {
         if (!checkbox.checked) {
@@ -35,7 +34,7 @@ export default class extends Controller {
       });
     }
 
-    // Toggle icons-selected class for each icon based on the state of corresponding checkbox
+
     this.checkboxTargets.forEach((checkbox, index) => {
       const icon = this.iconTargets[index];
       const name = this.nameTargets[index];

--- a/app/javascript/controllers/matching_modal_controller.js
+++ b/app/javascript/controllers/matching_modal_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["image", "link"];
+  static targets = ["image", "link", "checkbox", "icon", "name"];
 
   connect() {
     console.log("hey from the matching-modal controller");
@@ -12,5 +12,44 @@ export default class extends Controller {
     const imageSrc = event.currentTarget.querySelector('img').getAttribute('src');
     console.log(imageSrc);
     this.imageTarget.src = imageSrc;
+  }
+
+  toggle() {
+  let selectedCount = 0;
+
+    this.checkboxTargets.forEach(checkbox => {
+      if (checkbox.checked) {
+        selectedCount++;
+      }
+    });
+
+    console.log(selectedCount);
+
+    const maxlimit = 1;
+
+    if (selectedCount >= maxlimit) {
+      this.checkboxTargets.forEach(checkbox => {
+        if (!checkbox.checked) {
+          checkbox.disabled = true;
+        }
+      });
+    } else {
+      this.checkboxTargets.forEach(checkbox => {
+        checkbox.disabled = false;
+      });
+    }
+
+
+    this.checkboxTargets.forEach((checkbox, index) => {
+      const icon = this.iconTargets[index];
+      const name = this.nameTargets[index];
+      if (checkbox.checked) {
+        icon.classList.add("icons-selected");
+        name.classList.add("icons-selected-name");
+      } else {
+        icon.classList.remove("icons-selected");
+        name.classList.remove("icons-selected-name");
+      }
+    });
   }
 }

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -20,5 +20,5 @@
 <% end %>
   <div class="form-actions text-center">
     <%= render "devise/shared/links" %>
-  <div>
+  </div>
 </div>

--- a/app/views/events/_new.html.erb
+++ b/app/views/events/_new.html.erb
@@ -6,7 +6,20 @@
           </div>
           <div class="modal-body">
             <%= simple_form_for event, html: { data: { add_event_target: "form", action: "submit->add-event#create" } } do |f| %>
-              <%= f.input :hobby_id%>
+               <%= f.label :hobby_id, 'Select a hobby' %>
+            <div class="image-checkboxes" data-controller = "matching-modal">
+              <% Hobby.all.each do |hobby| %>
+                <% if hobby.photo.attached? %>
+                    <label >
+                      <div class="image-checkbox" data-matching-modal-target="icon">
+                        <%= cl_image_tag hobby.photo.key, class: "hobby-icon" %>
+                        <%= f.check_box :hobby_id, { autocomplete: "hobby", data: { matching_modal_target: "checkbox", action: "change->matching-modal#toggle" } }, hobby.id, nil %>
+                      </div>
+                      <p class="hobby-name" data-matching-modal-target="name" ><%= hobby.name %></p>
+                      </label>
+                    <% end %>
+                  <% end %>
+                </div>
               <%= f.input :name%>
               <%= f.input :location%>
               <%= f.input :date, as: :string, input_html: { data: { controller: "datepicker" }}%>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,6 +10,7 @@
 
   <div class="user-cards-container">
     <% @users.each do |user| %>
+    <% if user != current_user %>
       <div class="user-card">
       <div class="avatar-link">
       <h4><%= link_to user.username, user_path(user) %></h4>
@@ -31,6 +32,7 @@
           </div>
         </div>
       </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -62,7 +62,18 @@
   <ul>
   <% @events.each do |event| %>
     <div class="event-card" data-bs-toggle="modal" data-bs-target="#eventDetailModal<%= event.id %>">
-      <%= event.hobby_id%> | <%= event.name%> | <%= event.location%> | <%= event.date %>
+    <div class="d-flex align-items-center">
+      <div class="user-hobby-icons-container d-flex p-3">
+        <div class="user-hobby-icon-bg">
+          <% if event.hobby.photo.attached? %>
+            <%= cl_image_tag event.hobby.photo.key , class: "user-hobby-icons"%>
+          <% end %>
+        </div>
+      </div>
+      <div >
+        <%= event.name%> | <%= event.location%> | <%= event.date %>
+      </div>
+    </div>
     </div>
     <div class="modal fade" id="eventDetailModal<%= event.id %>" tabindex="-1" aria-labelledby="eventModalLabel" aria-hidden="true" data-controller="edit-event">
       <%= render "events/event_modal", event: event%>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDISCLOUD_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: hobby_connect_production


### PR DESCRIPTION
Added the icons to the Add an event modal and also added a line of code to not display the current_user profile in the index of profiles


![Capture d’écran 2024-03-25 à 08 44 04](https://github.com/barbara-bouillicot/HobbyConnect/assets/156521775/18ac3efb-9969-4a03-a052-b222ea3ff98b)
