### PR TITLE
display only current-user hobbies on event modal

### DIFF
--- a/app/views/events/_new.html.erb
+++ b/app/views/events/_new.html.erb
@@ -8,7 +8,7 @@
             <%= simple_form_for event, html: { data: { add_event_target: "form", action: "submit->add-event#create" } } do |f| %>
                <%= f.label :hobby_id, 'Select a hobby' %>
             <div class="image-checkboxes" data-controller = "matching-modal">
-              <% Hobby.all.each do |hobby| %>
+              <% current_user.hobbies.each do |hobby| %>
                 <% if hobby.photo.attached? %>
                     <label >
                       <div class="image-checkbox" data-matching-modal-target="icon">


### PR DESCRIPTION
Limited the display of hobbies to current_user hobbies on the add event modal

![Capture d’écran 2024-03-25 à 09 42 52](https://github.com/barbara-bouillicot/HobbyConnect/assets/156521775/af91f51f-a964-4492-8f76-ad6d18a5ffa6)
